### PR TITLE
Fix VS Code corrections issue

### DIFF
--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -31,5 +31,7 @@
   "eslint.enable": true,
   "eslint.validate": ["javascript", "javascriptreact", "vue"],
   "stylelint.enable": true,
+  
+  // Disables default checks:
   "javascript.validate.enable": false
 }

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -30,5 +30,6 @@
   // Linting:
   "eslint.enable": true,
   "eslint.validate": ["javascript", "javascriptreact", "vue"],
-  "stylelint.enable": true
+  "stylelint.enable": true,
+  "javascript.validate.enable": false
 }

--- a/template/.vscode/settings.json
+++ b/template/.vscode/settings.json
@@ -26,12 +26,10 @@
   "html.suggest.angular1": false,
   "html.suggest.ionic": false,
   "json.format.enable": false,
+  "javascript.validate.enable": false,
 
   // Linting:
   "eslint.enable": true,
   "eslint.validate": ["javascript", "javascriptreact", "vue"],
-  "stylelint.enable": true,
-  
-  // Disables default checks:
-  "javascript.validate.enable": false
+  "stylelint.enable": true
 }


### PR DESCRIPTION
With javascript.validate enabled, ESLint in VS Code treats .js files in Vue as JavaScript and shows errors when it detects TypeScript in them.