### PR TITLE
fix: ESLint doesn't work on WebStorm IDE

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     '@wemake-services/typescript/recommended',
     '@wemake-services/vue',
     '@wemake-services/jsdoc',
-    'plugin:@typescript-eslint/recommended',
     'plugin:nuxt/recommended',
     '@vue/typescript',
     'plugin:compat/recommended',
@@ -20,6 +19,9 @@ module.exports = {
     'json',
     'eslint-plugin-import-helpers',
   ],
+  'parserOptions': {
+    'parser': '@typescript-eslint/parser',
+  },
   'settings': {
     // providing polyfills for `eslint-plugin-compat` plugin, see:
     // https://github.com/amilajack/eslint-plugin-compat/wiki/Adding-polyfills


### PR DESCRIPTION
Consider changing '@vue/typescript' to '@nuxtjs/eslint-config-typescript'. @nuxtjs/eslint-config-typescript implements ESLint configuration suggested by Nuxt.js developers for both Javascript and Typescript, but it also defines some rules which would affect styleguide determined by this template. It's not necessary for this issue fix, so I didn't touched package.json dependencies. 

'plugin:@typescript-eslint/recommended' is simply a duplicate, because '@wemake-services/typescript/recommended' already extends it, and parserOptions.parser solves the issue.

Linters tests passed, everything works as expected